### PR TITLE
Added single download for a run.  Supports ERP.

### DIFF
--- a/lib/sra_tools.py
+++ b/lib/sra_tools.py
@@ -36,7 +36,7 @@ def safe_read(element, xpath, index=None, xpath_fallback=None):
 
 
 def get_accession_metadata(accession_id, sra_metadata_file):
-
+    print "Getting accession: {}".format(str(accession_id))
     params = { 'save': 'efetch', 'db': 'sra', 'rettype': 'docset', 'term': accession_id }
     retry_count = 0
     while True:
@@ -90,6 +90,12 @@ def get_accession_metadata(accession_id, sra_metadata_file):
         for run in experiment_package.xpath('RUN_SET/RUN'):
             rdata = {}
             rdata['run_id'] = safe_read(run, '@accession')[0]
+            my_out = "run: {}, exp: {}, study: {}".format(rdata['run_id'], exp['exp_id'], exp['study_id'])
+            if rdata['run_id'] != accession_id and accession_id != exp['exp_id'] and accession_id != exp['study_id']:
+                print "Skipping -- " + my_out
+                continue
+            else:
+                print "Using -- " + my_out
             rdata['accession'] = rdata['run_id']
             rdata['total_bases'] = int(safe_read(run, '@total_bases')[0])
             rdata['total_spots'] = int(safe_read(run, '@total_spots')[0])

--- a/scripts/p3-sra.py
+++ b/scripts/p3-sra.py
@@ -7,7 +7,7 @@ from sra_tools import download_sra_data
 if __name__ == '__main__':
 
     parser = argparse.ArgumentParser(description='A script to gather SRA data for a given accession id.',
-                usage='usage: ./p3_sra.py -bin <path to fasterq-dump> -out <fastq output directory> -id <SRA accession id (SRX, SRP, SRR)>')
+                usage='usage: ./p3_sra.py -bin <path to fasterq-dump> --out <fastq output directory> --id <SRA accession id (SRX, SRP, SRR, DRX, DRP, DRR, ERR, ERX, ERP)>')
 
     parser.add_argument('--bin', required=False, help='Path to the fasterq-dump binary', default="fasterq-dump")
     parser.add_argument('--out', required=False, help='Temporary output directory for fastq files')
@@ -23,7 +23,7 @@ if __name__ == '__main__':
         sys.exit("Output directory must be specified")
 
     accession_id = args.id
-    acceptable_prefixes = ('SRX', 'SRP', 'SRR', 'DRX', 'DRP', 'DRR', 'ERR')
+    acceptable_prefixes = ('SRX', 'SRP', 'SRR', 'DRX', 'DRP', 'DRR', 'ERR', 'ERX', 'ERP')
     if accession_id.startswith(acceptable_prefixes):
         download_sra_data(args.bin, args.out, accession_id, args.metaonly, args.gzip, args.metadata_file, args.sra_metadata_file)
     else:


### PR DESCRIPTION
I saw that the sra_import module was downloading entire experiments (multiple runs) when I gave it an ERR (a single run, ERR3549716).  I fixed the problem in my fork by skipping past runs if they didn't match the accession number.  It will still download all runs in experiments and studies.  The interface was enhanced to allow ERX and ERP.  Could this be merged into Patric?  Will it mess anything else up?
Jacob Porter