### PR TITLE
Python3 port

### DIFF
--- a/lib/sra_tools.py
+++ b/lib/sra_tools.py
@@ -381,7 +381,8 @@ def retry_subprocess_check_output(cmd, n_retries, retry_sleep):
         last_error = ret
         failed = True
 
-    print("Failed after %s retries running %s" % (attempt, cmd), file=sys.stderr)
-    raise ret
+    message = "Failed after %s retries running %s" % (attempt, cmd)
+    print(message, file=sys.stderr)
+    raise Exception(message)
 
 

--- a/lib/sra_tools.py
+++ b/lib/sra_tools.py
@@ -262,7 +262,7 @@ def get_run_ids(run_meta):
         run_ids.append(run['run_id'])
     return run_ids
 
-def download_fastq_files(fasterq_dump_loc, output_dir, metadata, gzip_output=True):
+def download_fastq_files(fasterq_dump_loc, output_dir, metadata, gzip_output=True, splitFiles=False):
 
     #
     # determine the list of ids to download
@@ -296,7 +296,9 @@ def download_fastq_files(fasterq_dump_loc, output_dir, metadata, gzip_output=Tru
             tmpdir = os.getenv("TMPDIR")
             if tmpdir is None:
                 tmpdir = "/tmp"
-            fasterq_dump_cmd = [fasterq_dump_loc, '-t', tmpdir, '--outdir', output_dir,  '--split-files', '-f', run_id]
+            fasterq_dump_cmd = [fasterq_dump_loc, '-t', tmpdir, '--outdir', output_dir, '-f', run_id]
+            if splitFiles: #optional, not needed, --split-3 is the default (see https://github.com/ncbi/sra-tools/wiki/HowTo:-fasterq-dump)
+                fasterq_dump_cmd.append('--split-files')
 
         try:
             # print >> sys.stderr, 'executing \'' + str(fasterq_dump_cmd) + '\''


### PR DESCRIPTION
Make "splitFiles" an optional parameter instead of the default.

Also, I observed a crash of Genome Assembly due to an error  in sra_tools.py:

  File "/opt/p3/deployment/lib/sra_tools.py", line 380, in retry_subprocess_check_output
    raise ret
TypeError: exceptions must be old-style classes or derived from BaseException, not int

So I fixed it by creating an Exception to raise based on the error message.